### PR TITLE
[Feat][mcp-essentials] Add Streamable HTTP MCP Server

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       ai:
         specifier: ^4.1.54
         version: 4.3.16(react@19.1.0)(zod@3.25.67)
+      express:
+        specifier: ^5.1.0
+        version: 5.1.0
       openai:
         specifier: ^4.86.1
         version: 4.104.0(zod@3.25.67)
@@ -109,6 +112,9 @@ importers:
       '@eslint/compat':
         specifier: ^1.2.4
         version: 1.3.0(eslint@9.29.0)
+      '@types/express':
+        specifier: ^5.0.3
+        version: 5.0.3
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -922,14 +928,29 @@ packages:
   '@types/babel__traverse@7.20.7':
     resolution: {integrity: sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
   '@types/diff-match-patch@1.0.36':
     resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/express-serve-static-core@5.0.7':
+    resolution: {integrity: sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ==}
+
+  '@types/express@5.0.3':
+    resolution: {integrity: sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==}
+
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -949,6 +970,9 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
+  '@types/mime@1.3.5':
+    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
   '@types/node-fetch@2.6.12':
     resolution: {integrity: sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==}
 
@@ -961,8 +985,20 @@ packages:
   '@types/node@22.15.32':
     resolution: {integrity: sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA==}
 
+  '@types/qs@6.14.0':
+    resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
+  '@types/send@0.17.5':
+    resolution: {integrity: sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==}
+
+  '@types/serve-static@1.15.8':
+    resolution: {integrity: sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -4295,13 +4331,37 @@ snapshots:
     dependencies:
       '@babel/types': 7.27.6
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 22.15.32
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 22.15.32
+
   '@types/diff-match-patch@1.0.36': {}
 
   '@types/estree@1.0.8': {}
 
+  '@types/express-serve-static-core@5.0.7':
+    dependencies:
+      '@types/node': 22.15.32
+      '@types/qs': 6.14.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 0.17.5
+
+  '@types/express@5.0.3':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.0.7
+      '@types/serve-static': 1.15.8
+
   '@types/graceful-fs@4.1.9':
     dependencies:
       '@types/node': 22.15.32
+
+  '@types/http-errors@2.0.5': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -4322,6 +4382,8 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
+  '@types/mime@1.3.5': {}
+
   '@types/node-fetch@2.6.12':
     dependencies:
       '@types/node': 22.15.32
@@ -4337,7 +4399,22 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/qs@6.14.0': {}
+
+  '@types/range-parser@1.2.7': {}
+
   '@types/retry@0.12.0': {}
+
+  '@types/send@0.17.5':
+    dependencies:
+      '@types/mime': 1.3.5
+      '@types/node': 22.15.32
+
+  '@types/serve-static@1.15.8':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 22.15.32
+      '@types/send': 0.17.5
 
   '@types/stack-utils@2.0.3': {}
 

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -40,6 +40,7 @@
   "license": "MIT",
   "devDependencies": {
     "@eslint/compat": "^1.2.4",
+    "@types/express": "^5.0.3",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.5",
     "@typescript-eslint/eslint-plugin": "^8.19.1",
@@ -59,6 +60,7 @@
   "dependencies": {
     "@commercetools/platform-sdk": "^8.5.0",
     "@commercetools/ts-client": "^3.2.0",
+    "express": "^5.1.0",
     "zod": "^3.24.2",
     "zod-to-json-schema": "^3.24.3"
   },

--- a/typescript/src/modelcontextprotocol/index.ts
+++ b/typescript/src/modelcontextprotocol/index.ts
@@ -1,4 +1,6 @@
 import CommercetoolsAgentEssentials from './essentials';
+import CommercetoolsAgentEssentialsStreamable from './streamable';
 export type {Configuration} from '../types/configuration';
 export type {AvailableNamespaces} from '../types/tools';
+export {CommercetoolsAgentEssentialsStreamable};
 export {CommercetoolsAgentEssentials};

--- a/typescript/src/modelcontextprotocol/streamable.ts
+++ b/typescript/src/modelcontextprotocol/streamable.ts
@@ -1,0 +1,153 @@
+import {
+  Configuration,
+  CommercetoolsAgentEssentials,
+} from '../modelcontextprotocol';
+import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  StreamableHTTPServerTransport,
+  StreamableHTTPServerTransportOptions,
+} from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import {isInitializeRequest} from '@modelcontextprotocol/sdk/types.js';
+import express, {Express, Request, Response} from 'express';
+import {randomUUID} from 'node:crypto';
+
+export default class CommercetoolsAgentEssentialsStreamable {
+  private app: Express;
+  private server: McpServer;
+  private transports: {[sessionId: string]: StreamableHTTPServerTransport} = {};
+
+  constructor({
+    clientId,
+    clientSecret,
+    authUrl,
+    projectKey,
+    apiUrl,
+    configuration,
+
+    stateless,
+    streamableHttpOptions,
+    app,
+  }: {
+    clientId: string;
+    clientSecret: string;
+    authUrl: string;
+    projectKey: string;
+    apiUrl: string;
+    configuration: Configuration;
+
+    // streamable http configuration
+    stateless?: boolean;
+    streamableHttpOptions: StreamableHTTPServerTransportOptions;
+
+    // express app instance
+    app?: Express;
+  }) {
+    // initialize the mcp server
+    this.server = new CommercetoolsAgentEssentials({
+      clientId,
+      clientSecret,
+      authUrl,
+      projectKey,
+      apiUrl,
+      configuration,
+    });
+
+    // initialize express app
+    this.app = app ?? express();
+    this.app.use(express.json());
+
+    /**
+     * streambale endpoint
+     */
+    this.app.post('/mcp', async (req: Request, res: Response) => {
+      try {
+        let transport: StreamableHTTPServerTransport;
+
+        // if stateless then close each transport and server after use
+        if (stateless) {
+          transport = new StreamableHTTPServerTransport({
+            ...streamableHttpOptions,
+            sessionIdGenerator: undefined,
+          });
+          res.on('close', async () => {
+            // close the transport and server
+            await transport.close();
+            await this.server.close();
+          });
+
+          // connect server to the transport
+          await this.server.connect(transport);
+          await transport.handleRequest(req, res, req.body);
+        } else {
+          const sessionId = req.headers['mcp-session-id'] as string | undefined;
+          if (sessionId && this.transports[sessionId]) {
+            transport = this.transports[sessionId];
+          } else if (!sessionId && isInitializeRequest(req.body)) {
+            const generator =
+              streamableHttpOptions.sessionIdGenerator &&
+              typeof streamableHttpOptions.sessionIdGenerator == 'function'
+                ? streamableHttpOptions.sessionIdGenerator
+                : randomUUID;
+
+            transport = new StreamableHTTPServerTransport({
+              sessionIdGenerator: generator,
+              onsessioninitialized: (sessionId) => {
+                // Store the transport by session ID
+                this.transports[sessionId] = transport;
+              },
+            });
+
+            // Clean up transport when closed
+            transport.onclose = () => {
+              if (transport.sessionId) {
+                delete this.transports[transport.sessionId];
+              }
+            };
+
+            // connect server to the transport
+            await this.server.connect(transport);
+          } else {
+            return res.status(400).json({
+              jsonrpc: '2.0',
+              error: {
+                code: -32000,
+                message: 'Bad Request: No valid session ID provided',
+              },
+              id: null,
+            });
+          }
+        }
+
+        // finally handle requests
+        await transport.handleRequest(req, res, req.body);
+      } catch (err: unknown) {
+        // handle error
+        console.error('Error handling request', err);
+        if (!res.headersSent) {
+          res.status(500).json({
+            jsonrpc: '2.0',
+            error: {
+              code: -32603,
+              message: 'Internal server error',
+            },
+            id: null,
+          });
+        }
+      }
+    });
+
+    /**
+     * sse endpoint
+     *
+     * TODO:
+     * decide on how to handle SSE requests
+     */
+    this.app.get('/mcp', async (req: Request, res: Response) => {
+      /* noop */
+    });
+  }
+
+  listen(port: number, cb?: () => void) {
+    this.app.listen(port, cb);
+  }
+}


### PR DESCRIPTION
### Summary
Add functionality for Streamable HTTP MCP Server

### Completed Tasks
- [x] add functionality for streamable http mcp server
- [x] add options to toggle between stateless and stateful streamable http server

### Developer Notes
To manually test this functionality, follow the steps below:

- [ ] Pull and checkout the branch `feat/add-streamable-http-mcp-server` 
- [ ] Run `pnpm run build`
- [ ] Create a file called `test.ts` and paste the snippet below.

```ts
import {CommercetoolsAgentEssentialsStreamable} from '@commercetools/agent-essentials/modelcontextprotocol';

const server = new CommercetoolsAgentEssentialsStreamable({
  clientId: process.env.CTP_CLIENT_ID!,
  clientSecret: process.env.CTP_CLIENT_SECRET!,
  projectKey: process.env.CTP_PROJECT_KEY!,
  authUrl: process.env.CTP_AUTH_URL!,
  apiUrl: process.env.CTP_API_URL!,
  configuration: {
    actions: {
      project: {
        read: true,
      },
      // other tools can go here
    },
  },

  stateless: false,                   // option to make the MCP server stateless/stateful
  streamableHttpOptions: {
    sessionIdGenerator: undefined,
  },
});

server.listen(8888, function () {
  console.log('listening on 8888');
});

```
- [ ] Run the MCP server using `node test.ts` or `bun test.ts` if using `bun`
- [ ] Testing with `MCP inspector` run `npx @modelcontextprotocol/inspector` and switch the `Transport Type` to Streamable HTTP and the `url` is `http://localhost:3000/mcp`.