### PR TITLE
[Fix] Scope and Action Case Mismatch

### DIFF
--- a/.changeset/flat-shirts-reply.md
+++ b/.changeset/flat-shirts-reply.md
@@ -1,0 +1,5 @@
+---
+"@commercetools/agent-essentials": patch
+---
+
+[Fix] Scope and Action Case Mismatch

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "@changesets/cli": "^2.29.4",
     "@commercetools/agent-essentials": "workspace:*",
     "@commercetools/platform-sdk": "^8.13.0",
-    "@commercetools/ts-client": "^4.2.0"
+    "@commercetools/ts-client": "^4.2.0",
+    "@types/pluralize": "^0.0.33"
   },
   "packageManager": "pnpm@9.11.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@commercetools/ts-client':
         specifier: ^4.2.0
         version: 4.2.0
+      '@types/pluralize':
+        specifier: ^0.0.33
+        version: 0.0.33
 
   modelcontextprotocol:
     dependencies:
@@ -114,6 +117,9 @@ importers:
       openai:
         specifier: ^4.86.1
         version: 4.104.0(zod@3.25.76)
+      pluralize:
+        specifier: ^8.0.0
+        version: 8.0.0
       zod:
         specifier: ^3.24.2
         version: 3.25.76
@@ -1009,6 +1015,9 @@ packages:
 
   '@types/node@24.3.0':
     resolution: {integrity: sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==}
+
+  '@types/pluralize@0.0.33':
+    resolution: {integrity: sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg==}
 
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
@@ -2911,6 +2920,10 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
+  pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -4604,6 +4617,8 @@ snapshots:
     dependencies:
       undici-types: 7.10.0
     optional: true
+
+  '@types/pluralize@0.0.33': {}
 
   '@types/qs@6.14.0': {}
 
@@ -6859,6 +6874,8 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.7.4
       pathe: 2.0.3
+
+  pluralize@8.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
 

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -66,6 +66,7 @@
     "@commercetools/platform-sdk": "^8.13.0",
     "@commercetools/ts-client": "^4.2.0",
     "express": "^5.1.0",
+    "pluralize": "^8.0.0",
     "zod": "^3.24.2",
     "zod-to-json-schema": "^3.24.3"
   },

--- a/typescript/src/modelcontextprotocol/__tests__/essentials.test.ts
+++ b/typescript/src/modelcontextprotocol/__tests__/essentials.test.ts
@@ -475,7 +475,7 @@ describe('CommercetoolsAgentEssentials (ModelContextProtocol)', () => {
         });
     });
 
-    it('init commercetoolsAgentEssentials', async () => {
+    it('init commercetoolsAgentEssentials', () => {
       const agentEssentials = CommercetoolsAgentEssentials.create({
         authConfig: {
           clientId: 'id',
@@ -489,10 +489,6 @@ describe('CommercetoolsAgentEssentials (ModelContextProtocol)', () => {
       });
 
       expect(_mockCommercetoolsAPIInstance.introspect()).toEqual(['view_cart']);
-      expect((await agentEssentials).getConfig()).toEqual({
-        actions: {cart: {read: true}},
-        context: {isAdmin: true},
-      });
     });
 
     it('should properly handle error', () => {

--- a/typescript/src/modelcontextprotocol/essentials.ts
+++ b/typescript/src/modelcontextprotocol/essentials.ts
@@ -12,7 +12,6 @@ import {AuthConfig} from '../types/auth';
 class CommercetoolsAgentEssentials extends McpServer {
   private authConfig: AuthConfig;
   private configuration: Configuration;
-  private filteredConfig: Configuration = {};
 
   private constructor({
     authConfig,
@@ -61,7 +60,6 @@ class CommercetoolsAgentEssentials extends McpServer {
       (tool) => isToolAllowed(tool, processedConfiguration)
     );
 
-    this.setConfig(processedConfiguration);
     filteredTools.forEach((tool) => {
       this.tool(
         tool.method,
@@ -96,14 +94,6 @@ class CommercetoolsAgentEssentials extends McpServer {
           'Unable to initialze `CommercetoolsAgentEssentials`'
       );
     }
-  }
-
-  getConfig(): Configuration {
-    return this.filteredConfig;
-  }
-
-  setConfig(config: Configuration): void {
-    this.filteredConfig = config;
   }
 }
 

--- a/typescript/src/utils/scopes.ts
+++ b/typescript/src/utils/scopes.ts
@@ -5,6 +5,10 @@ type Permission = {[actions: string]: boolean};
 
 const adminScope = ['manage_project', 'manage_api_clients', 'view_api_clients'];
 
+function normalize(str: string) {
+  return str.replace(/s$/, '').toLowerCase();
+}
+
 export function scopesToActions(
   scopes: Array<string>,
   configuration: Configuration
@@ -35,6 +39,8 @@ export function scopesToActions(
     }
 
     const resource = resourceParts.join('-');
+    const normalizedResource = normalize(resource);
+
     const permissions =
       // eslint-disable-next-line no-nested-ternary
       type == 'view'
@@ -43,12 +49,16 @@ export function scopesToActions(
           ? ['read', 'create', 'update']
           : [];
 
-    if (!actions[resource]) return acc;
+    const resourceKey = Object.keys(actions).find((key) => {
+      return normalizedResource.startsWith(normalize(key));
+    });
 
-    acc[resource] = acc[resource] || {};
+    if (!resourceKey) return acc;
+
+    acc[resourceKey] = acc[resourceKey] || {};
     permissions.forEach((permission) => {
-      if (permission in actions[resource]) {
-        acc[resource][permission] = actions[resource][permission];
+      if (permission in actions[resourceKey]) {
+        acc[resourceKey][permission] = actions[resourceKey][permission];
       }
     });
 

--- a/typescript/src/utils/scopes.ts
+++ b/typescript/src/utils/scopes.ts
@@ -6,10 +6,6 @@ type Permission = {[actions: string]: boolean};
 
 const adminScope = ['manage_project', 'manage_api_clients', 'view_api_clients'];
 
-// function normalize(str: string) {
-//   return str.replace(/s$/, '').toLowerCase();
-// }
-
 function normalize(str: string): string {
   return pluralize.plural(str).toLowerCase();
 }

--- a/typescript/src/utils/scopes.ts
+++ b/typescript/src/utils/scopes.ts
@@ -1,3 +1,4 @@
+import pluralize from 'pluralize';
 import {Actions, Configuration} from '../types/configuration';
 
 type Action = {[key: string]: Permission};
@@ -5,8 +6,12 @@ type Permission = {[actions: string]: boolean};
 
 const adminScope = ['manage_project', 'manage_api_clients', 'view_api_clients'];
 
-function normalize(str: string) {
-  return str.replace(/s$/, '').toLowerCase();
+// function normalize(str: string) {
+//   return str.replace(/s$/, '').toLowerCase();
+// }
+
+function normalize(str: string): string {
+  return pluralize.plural(str).toLowerCase();
 }
 
 export function scopesToActions(


### PR DESCRIPTION
### Summary
There is a mismatch between resource names from some scopes and action names, such as `customer` from action and `customers` from scope. This PR is an attempt to fix this mismatch.

### Complete Tasks
- [x] fix issue with scope filtering such as cart and carts, customer and customers
- [x] fuzzy and partially match actions resource name and scope resource
- [x] remove unnecessary class methods and associated tests