### PR TITLE
[Fix] Issue With Session ID Not Being Passed To Client

### DIFF
--- a/.changeset/pink-clouds-deny.md
+++ b/.changeset/pink-clouds-deny.md
@@ -1,0 +1,5 @@
+---
+"@commercetools/agent-essentials": patch
+---
+
+Fix issue with session id not being passed to client

--- a/typescript/src/modelcontextprotocol/streamable.ts
+++ b/typescript/src/modelcontextprotocol/streamable.ts
@@ -43,9 +43,9 @@ export default class CommercetoolsAgentEssentialsStreamable {
     this.app.post('/mcp', async (req, res) => {
       try {
         let transport: StreamableHTTPServerTransport;
+        let serverInstance = await this.getServer();
         const authHeader = req.headers.authorization as string | undefined;
         const token = authHeader?.split(' ')[1] as string;
-        const serverInstance = await this.getServer();
         /**
          * if token already exists in the config,
          * use it else use header provided token
@@ -89,6 +89,7 @@ export default class CommercetoolsAgentEssentialsStreamable {
                 this.transports[sessionId] = transport;
 
                 // connect server to the transport
+                serverInstance = await this.getServer(sessionId);
                 await serverInstance.connect(transport);
               },
             });


### PR DESCRIPTION
### Summary
SessionID not being passed to api client

### Completed Tasks
- [x] call and pass the sessionId to the `getServer()` function and reassign to existing instance.