### PR TITLE
Added fieldType to search_products

### DIFF
--- a/.changeset/wicked-pants-cut.md
+++ b/.changeset/wicked-pants-cut.md
@@ -1,0 +1,8 @@
+---
+"@commercetools/mcp-essentials": minor
+"@commercetools/agent-essentials": minor
+---
+
+Added [fieldType](https://docs.commercetools.com/api/search-query-language#ctp:api:type:SearchFieldType) to search_products
+
+Necessary when sorting by attributes to avoid errors like: `SDKError: Failed to search products Field [variants.attributes.weight]: Type is missing`

--- a/typescript/src/shared/product-search/parameters.ts
+++ b/typescript/src/shared/product-search/parameters.ts
@@ -18,6 +18,35 @@ export const searchProductsParameters = z.object({
           .enum(['min', 'max'])
           .optional()
           .describe('The sorting mode for multi-valued fields'),
+        fieldType: z
+          .enum([
+            'boolean',
+            'text',
+            'ltext',
+            'enum',
+            'lenum',
+            'number',
+            'money',
+            'date',
+            'datetime',
+            'time',
+            'reference',
+            'set_boolean',
+            'set_text',
+            'set_ltext',
+            'set_enum',
+            'set_lenum',
+            'set_number',
+            'set_money',
+            'set_date',
+            'set_datetime',
+            'set_time',
+            'set_reference',
+          ])
+          .optional()
+          .describe(
+            'The data type of the field. Must be provided when field is a non-standard field on a resource, like a Product Attribute'
+          ),
       })
     )
     .optional()


### PR DESCRIPTION
- https://docs.commercetools.com/api/search-query-language#ctp:api:type:SearchFieldType
- Necessary when sorting by attributes to avoid errors like: `SDKError: Failed to search products Field [variants.attributes.weight]: Type is missing`