### PR TITLE
Add Dependabot config for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,67 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - javascript
+    groups:
+      non-major:
+        update-types:
+          - minor
+          - patch
+      types:
+        patterns:
+          - "@types/*"
+
+  - package-ecosystem: npm
+    directory: /typescript/examples/ai-sdk
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - javascript
+      - examples
+    groups:
+      non-major:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /typescript/examples/langchain
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - javascript
+      - examples
+    groups:
+      non-major:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      actions:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` so version updates are picked up (today only security updates run; no scheduled version-update config exists).
- Covers: root pnpm workspace (typescript + modelcontextprotocol), the two example app dirs with their own `package.json` (`typescript/examples/ai-sdk`, `typescript/examples/langchain`), and GitHub Actions.

## Noise control
- Weekly Monday schedule.
- Minor + patch updates **grouped** per ecosystem into a single PR; majors stay individual so they get proper review.
- `@types/*` further grouped at the root.
- Open-PR caps: 5 root / 3 per other ecosystem.
- Labels match what Dependabot was already applying on previous PRs (`dependencies`, `javascript`).

## Test plan
- [ ] After merge, confirm Dependabot opens a first round of grouped PRs on the next Monday window (or trigger immediately via Insights → Dependency graph → Dependabot → "Check for updates").
- [ ] Sanity-check that workflow updates surface for `actions/checkout@v4`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)