### PR TITLE
Group coupled deps (langchain, Vercel AI SDK) in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,10 @@ updates:
       - javascript
       - examples
     groups:
+      vercel-ai-sdk:
+        patterns:
+          - "ai"
+          - "@ai-sdk/*"
       non-major:
         update-types:
           - minor
@@ -46,6 +50,10 @@ updates:
       - javascript
       - examples
     groups:
+      langchain:
+        patterns:
+          - "langchain"
+          - "@langchain/*"
       non-major:
         update-types:
           - minor


### PR DESCRIPTION
## Summary
Adds package-pattern groups for tightly-coupled dependencies in the example apps:

- \`langchain\` + \`@langchain/*\` (langchain example)
- \`ai\` + \`@ai-sdk/*\` (ai-sdk example)

Bumping these in isolation creates unmergeable PRs because they share peer-dep contracts (current cases: #57, #61). Grouping makes Dependabot raise a single coordinated PR per ecosystem, which can be migrated as a unit alongside the corresponding code changes in \`index.ts\`.

## Notes
- Closing #57 and #61 against tracking issues #67 / #68; Dependabot will reopen as a grouped PR on the next bump.
- Non-major group rules are kept unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)