### PR TITLE
Migrate to zod v4

### DIFF
--- a/.changeset/zod-v4-migration.md
+++ b/.changeset/zod-v4-migration.md
@@ -1,0 +1,10 @@
+---
+"@commercetools/agent-essentials": major
+"@commercetools/mcp-essentials": major
+---
+
+Upgrade `zod` from v3 to v4 (`^4.0.0`).
+
+Consumers that define custom tools or extend the SDK with their own zod schemas will need to migrate to zod v4 as well. The `ZodObject` generic now takes two type parameters instead of four/five, and `ZodError.issues` replaces the deprecated `.errors` / `.formErrors` accessors. See the [zod v4 migration guide](https://zod.dev/v4/changelog) for details.
+
+The unused `zod-to-json-schema` dependency has been removed; if you used it transitively, switch to the native `z.toJSONSchema()` in zod v4.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: link:../typescript
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       colors:
         specifier: ^1.4.0
         version: 1.4.0
@@ -107,7 +107,7 @@ importers:
         version: 4.9.3
       '@langchain/core':
         specifier: ^0.3.6
-        version: 0.3.71(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))
+        version: 0.3.71(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@4.4.3))
       '@mastra/core':
         specifier: ^0.8.0
         version: 0.8.3(openapi-types@12.1.3)(react@19.1.1)
@@ -116,22 +116,19 @@ importers:
         version: 1.17.3
       ai:
         specifier: ^4.1.54
-        version: 4.3.19(react@19.1.1)(zod@3.25.76)
+        version: 4.3.19(react@19.1.1)(zod@4.4.3)
       express:
         specifier: ^5.2.1
         version: 5.2.1
       openai:
         specifier: ^4.86.1
-        version: 4.104.0(ws@8.18.3)(zod@3.25.76)
+        version: 4.104.0(ws@8.18.3)(zod@4.4.3)
       pluralize:
         specifier: ^8.0.0
         version: 8.0.0
       zod:
-        specifier: ^3.24.2
-        version: 3.25.76
-      zod-to-json-schema:
-        specifier: ^3.25.2
-        version: 3.25.2(zod@3.25.76)
+        specifier: ^4.0.0
+        version: 4.4.3
     devDependencies:
       '@eslint/compat':
         specifier: ^2.1.0
@@ -3795,7 +3792,6 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lilconfig@3.1.3:
@@ -5121,6 +5117,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
 
   '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
@@ -5129,6 +5128,13 @@ snapshots:
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
       zod: 3.25.76
+
+  '@ai-sdk/provider-utils@2.2.8(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      nanoid: 3.3.11
+      secure-json-parse: 2.7.0
+      zod: 4.4.3
 
   '@ai-sdk/provider@1.1.3':
     dependencies:
@@ -5144,12 +5150,29 @@ snapshots:
     optionalDependencies:
       zod: 3.25.76
 
+  '@ai-sdk/react@1.2.12(react@19.1.1)(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
+      '@ai-sdk/ui-utils': 1.2.11(zod@4.4.3)
+      react: 19.1.1
+      swr: 2.3.6(react@19.1.1)
+      throttleit: 2.1.0
+    optionalDependencies:
+      zod: 4.4.3
+
   '@ai-sdk/ui-utils@1.2.11(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
+
+  '@ai-sdk/ui-utils@1.2.11(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -6355,14 +6378,14 @@ snapshots:
 
   '@jsdevtools/ono@7.1.3': {}
 
-  '@langchain/core@0.3.71(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))':
+  '@langchain/core@0.3.71(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@4.4.3))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.3.61(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))
+      langsmith: 0.3.61(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@4.4.3))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -6515,7 +6538,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.22)
       ajv: 8.20.0
@@ -6532,8 +6555,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     optionalDependencies:
       '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
@@ -7968,6 +7991,18 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       jsondiffpatch: 0.6.0
       zod: 3.25.76
+    optionalDependencies:
+      react: 19.1.1
+
+  ai@4.3.19(react@19.1.1)(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
+      '@ai-sdk/react': 1.2.12(react@19.1.1)(zod@4.4.3)
+      '@ai-sdk/ui-utils': 1.2.11(zod@4.4.3)
+      '@opentelemetry/api': 1.9.0
+      jsondiffpatch: 0.6.0
+      zod: 4.4.3
     optionalDependencies:
       react: 19.1.1
 
@@ -9897,7 +9932,7 @@ snapshots:
 
   kleur@3.0.3: {}
 
-  langsmith@0.3.61(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76)):
+  langsmith@0.3.61(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@4.4.3)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -9910,7 +9945,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/exporter-trace-otlp-proto': 0.57.2(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
-      openai: 4.104.0(ws@8.18.3)(zod@3.25.76)
+      openai: 4.104.0(ws@8.18.3)(zod@4.4.3)
 
   leven@3.1.0: {}
 
@@ -10182,7 +10217,7 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
-  openai@4.104.0(ws@8.18.3)(zod@3.25.76):
+  openai@4.104.0(ws@8.18.3)(zod@4.4.3):
     dependencies:
       '@types/node': 18.19.123
       '@types/node-fetch': 2.6.13
@@ -10193,7 +10228,7 @@ snapshots:
       node-fetch: 2.7.0
     optionalDependencies:
       ws: 8.18.3
-      zod: 3.25.76
+      zod: 4.4.3
     transitivePeerDependencies:
       - encoding
 
@@ -11272,4 +11307,10 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
   zod@3.25.76: {}
+
+  zod@4.4.3: {}

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -75,8 +75,7 @@
     "@commercetools/ts-client": "^4.9.3",
     "express": "^5.2.1",
     "pluralize": "^8.0.0",
-    "zod": "^3.24.2",
-    "zod-to-json-schema": "^3.25.2"
+    "zod": "^4.0.0"
   },
   "peerDependencies": {
     "@langchain/core": "^0.3.6",

--- a/typescript/src/ai-sdk/tool.ts
+++ b/typescript/src/ai-sdk/tool.ts
@@ -8,7 +8,7 @@ export default function CommercetoolsTool(
   commercetoolsAPI: CommercetoolsAPI,
   method: string,
   description: string,
-  schema: z.ZodObject<any, any, any, any, {[x: string]: any}>,
+  schema: z.ZodObject<any, any>,
   toolOutputFormat?: 'json' | 'tabular'
 ): Tool {
   return tool({

--- a/typescript/src/langchain/essentials.ts
+++ b/typescript/src/langchain/essentials.ts
@@ -13,7 +13,7 @@ import {AuthConfig} from '../types/auth';
 interface ToolDefinition {
   method: string;
   description: string;
-  parameters: z.ZodObject<any, any, any, any>;
+  parameters: z.ZodObject<any, any>;
   name: string;
   actions: any;
 }

--- a/typescript/src/langchain/tool.ts
+++ b/typescript/src/langchain/tool.ts
@@ -9,7 +9,7 @@ export default function CommercetoolsTool(
   commercetoolsAPI: CommercetoolsAPI,
   method: string,
   description: string,
-  schema: z.ZodObject<any, any, any, any, {[x: string]: any}>,
+  schema: z.ZodObject<any, any>,
   toolOutputFormat?: 'json' | 'tabular'
 ): DynamicStructuredTool {
   return new DynamicStructuredTool({

--- a/typescript/src/mastra/tool.ts
+++ b/typescript/src/mastra/tool.ts
@@ -7,9 +7,9 @@ export default function CommercetoolsTool(
   commercetoolsAPI: CommercetoolsAPI,
   method: string,
   description: string,
-  schema: z.ZodObject<any, any, any, any, {[x: string]: any}>,
+  schema: z.ZodObject<any, any>,
   toolOutputFormat?: 'json' | 'tabular'
-) {
+): ReturnType<typeof createTool> {
   return createTool({
     id: method,
     description,

--- a/typescript/src/shared/business-unit/tools.ts
+++ b/typescript/src/shared/business-unit/tools.ts
@@ -18,12 +18,7 @@ const tools: Record<string, Tool> = {
     method: 'read_business_unit',
     name: 'Read Business Unit',
     description: readBusinessUnitPrompt,
-    parameters: readBusinessUnitParameters as unknown as z.ZodObject<
-      any,
-      any,
-      any,
-      any
-    >,
+    parameters: readBusinessUnitParameters as unknown as z.ZodObject<any, any>,
     actions: {
       'business-unit': {
         read: true,
@@ -35,8 +30,6 @@ const tools: Record<string, Tool> = {
     name: 'Create Business Unit',
     description: createBusinessUnitPrompt,
     parameters: createBusinessUnitParameters as unknown as z.ZodObject<
-      any,
-      any,
       any,
       any
     >,
@@ -51,8 +44,6 @@ const tools: Record<string, Tool> = {
     name: 'Update Business Unit',
     description: updateBusinessUnitPrompt,
     parameters: updateBusinessUnitParameters as unknown as z.ZodObject<
-      any,
-      any,
       any,
       any
     >,

--- a/typescript/src/shared/cart/tools.ts
+++ b/typescript/src/shared/cart/tools.ts
@@ -20,12 +20,7 @@ const tools: Record<string, Tool> = {
     method: 'read_cart',
     name: 'Read Cart',
     description: readCartPrompt,
-    parameters: readCartParameters as unknown as z.ZodObject<
-      any,
-      any,
-      any,
-      any
-    >,
+    parameters: readCartParameters as unknown as z.ZodObject<any, any>,
     actions: {
       cart: {
         read: true,
@@ -36,12 +31,7 @@ const tools: Record<string, Tool> = {
     method: 'create_cart',
     name: 'Create Cart',
     description: createCartPrompt,
-    parameters: createCartParameters as unknown as z.ZodObject<
-      any,
-      any,
-      any,
-      any
-    >,
+    parameters: createCartParameters as unknown as z.ZodObject<any, any>,
     actions: {
       cart: {
         create: true,
@@ -52,12 +42,7 @@ const tools: Record<string, Tool> = {
     method: 'replicate_cart',
     name: 'Replicate Cart',
     description: replicateCartPrompt,
-    parameters: replicateCartParameters as unknown as z.ZodObject<
-      any,
-      any,
-      any,
-      any
-    >,
+    parameters: replicateCartParameters as unknown as z.ZodObject<any, any>,
     actions: {
       cart: {
         create: true,
@@ -68,12 +53,7 @@ const tools: Record<string, Tool> = {
     method: 'update_cart',
     name: 'Update Cart',
     description: updateCartPrompt,
-    parameters: updateCartParameters as unknown as z.ZodObject<
-      any,
-      any,
-      any,
-      any
-    >,
+    parameters: updateCartParameters as unknown as z.ZodObject<any, any>,
     actions: {
       cart: {
         update: true,

--- a/typescript/src/shared/customer-group/test/customerGroup.test.ts
+++ b/typescript/src/shared/customer-group/test/customerGroup.test.ts
@@ -488,10 +488,7 @@ describe('CustomerGroup Functions', () => {
         });
         expect(result.success).toBe(false);
         if (!result.success) {
-          // Check for the specific refine error message
-          const formErrors = result.error.formErrors.fieldErrors;
-          // Zod nests refine errors under _errors array for the object itself
-          expect(result.error.errors[0].message).toBe(
+          expect(result.error.issues[0].message).toBe(
             'Either id or key must be provided'
           );
         }
@@ -530,8 +527,7 @@ describe('CustomerGroup Functions', () => {
           });
           expect(result.success).toBe(false);
           if (!result.success) {
-            const formErrors = result.error.formErrors.fieldErrors;
-            expect(result.error.errors[0].message).toBe(
+            expect(result.error.issues[0].message).toBe(
               'Either id or key must be provided'
             );
           }

--- a/typescript/src/shared/customer-group/tools.ts
+++ b/typescript/src/shared/customer-group/tools.ts
@@ -18,12 +18,7 @@ const tools: Record<string, Tool> = {
     method: 'read_customer_group',
     name: 'Read Customer Group',
     description: READ_CUSTOMER_GROUP_PROMPT,
-    parameters: readCustomerGroupParameters as unknown as z.ZodObject<
-      any,
-      any,
-      any,
-      any
-    >,
+    parameters: readCustomerGroupParameters as unknown as z.ZodObject<any, any>,
     actions: {
       'customer-group': {
         read: true,
@@ -35,8 +30,6 @@ const tools: Record<string, Tool> = {
     name: 'Create Customer Group',
     description: CREATE_CUSTOMER_GROUP_PROMPT,
     parameters: createCustomerGroupParametersSchema as unknown as z.ZodObject<
-      any,
-      any,
       any,
       any
     >,
@@ -51,8 +44,6 @@ const tools: Record<string, Tool> = {
     name: 'Update Customer Group',
     description: UPDATE_CUSTOMER_GROUP_PROMPT,
     parameters: updateCustomerGroupParameters as unknown as z.ZodObject<
-      any,
-      any,
       any,
       any
     >,

--- a/typescript/src/shared/order/tools.ts
+++ b/typescript/src/shared/order/tools.ts
@@ -25,12 +25,7 @@ const tools: Record<string, Tool> = {
     method: 'create_order',
     name: 'Create Order',
     description: createOrderPrompt,
-    parameters: createOrderParameters as unknown as z.ZodObject<
-      any,
-      any,
-      any,
-      any
-    >,
+    parameters: createOrderParameters as unknown as z.ZodObject<any, any>,
     actions: {
       order: {
         create: true,

--- a/typescript/src/shared/quote-request/tools.ts
+++ b/typescript/src/shared/quote-request/tools.ts
@@ -18,12 +18,7 @@ const tools: Record<string, Tool> = {
     method: 'read_quote_request',
     name: 'Read Quote Request',
     description: readQuoteRequestPrompt,
-    parameters: readQuoteRequestParameters as unknown as z.ZodObject<
-      any,
-      any,
-      any,
-      any
-    >,
+    parameters: readQuoteRequestParameters as unknown as z.ZodObject<any, any>,
     actions: {
       'quote-request': {
         read: true,
@@ -35,8 +30,6 @@ const tools: Record<string, Tool> = {
     name: 'Create Quote Request',
     description: createQuoteRequestPrompt,
     parameters: createQuoteRequestParameters as unknown as z.ZodObject<
-      any,
-      any,
       any,
       any
     >,
@@ -51,8 +44,6 @@ const tools: Record<string, Tool> = {
     name: 'Update Quote Request',
     description: updateQuoteRequestPrompt,
     parameters: updateQuoteRequestParameters as unknown as z.ZodObject<
-      any,
-      any,
       any,
       any
     >,

--- a/typescript/src/shared/quote/tools.ts
+++ b/typescript/src/shared/quote/tools.ts
@@ -14,12 +14,7 @@ const tools: Record<string, Tool> = {
     method: 'read_quote',
     name: 'Read Quote',
     description: readQuotePrompt,
-    parameters: readQuoteParameters as unknown as z.ZodObject<
-      any,
-      any,
-      any,
-      any
-    >,
+    parameters: readQuoteParameters as unknown as z.ZodObject<any, any>,
     actions: {
       quote: {
         read: true,
@@ -30,12 +25,7 @@ const tools: Record<string, Tool> = {
     method: 'create_quote',
     name: 'Create Quote',
     description: createQuotePrompt,
-    parameters: createQuoteParameters as unknown as z.ZodObject<
-      any,
-      any,
-      any,
-      any
-    >,
+    parameters: createQuoteParameters as unknown as z.ZodObject<any, any>,
     actions: {
       quote: {
         create: true,
@@ -46,12 +36,7 @@ const tools: Record<string, Tool> = {
     method: 'update_quote',
     name: 'Update Quote',
     description: updateQuotePrompt,
-    parameters: updateQuoteParameters as unknown as z.ZodObject<
-      any,
-      any,
-      any,
-      any
-    >,
+    parameters: updateQuoteParameters as unknown as z.ZodObject<any, any>,
     actions: {
       quote: {
         update: true,

--- a/typescript/src/shared/store/tools.ts
+++ b/typescript/src/shared/store/tools.ts
@@ -14,12 +14,7 @@ const tools: Record<string, Tool> = {
     method: 'read_store',
     name: 'Read Store',
     description: readStorePrompt,
-    parameters: readStoreParameters as unknown as z.ZodObject<
-      any,
-      any,
-      any,
-      any
-    >,
+    parameters: readStoreParameters as unknown as z.ZodObject<any, any>,
     actions: {
       store: {
         read: true,
@@ -30,12 +25,7 @@ const tools: Record<string, Tool> = {
     method: 'create_store',
     name: 'Create Store',
     description: createStorePrompt,
-    parameters: createStoreParameters as unknown as z.ZodObject<
-      any,
-      any,
-      any,
-      any
-    >,
+    parameters: createStoreParameters as unknown as z.ZodObject<any, any>,
     actions: {
       store: {
         create: true,
@@ -46,12 +36,7 @@ const tools: Record<string, Tool> = {
     method: 'update_store',
     name: 'Update Store',
     description: updateStorePrompt,
-    parameters: updateStoreParameters as unknown as z.ZodObject<
-      any,
-      any,
-      any,
-      any
-    >,
+    parameters: updateStoreParameters as unknown as z.ZodObject<any, any>,
     actions: {
       store: {
         update: true,

--- a/typescript/src/types/tools.ts
+++ b/typescript/src/types/tools.ts
@@ -42,7 +42,7 @@ export type Tool = {
   method: string;
   name: string;
   description: string;
-  parameters: z.ZodObject<any, any, any, any>;
+  parameters: z.ZodObject<any, any>;
   execute?: <T = any, R = string>(args: T, api?: ApiRoot) => Promise<R>;
   actions: {
     [key: string]: {


### PR DESCRIPTION
## Summary
Upgrades \`zod\` from \`^3.24.2\` to \`^4.0.0\` and adapts the codebase to the v4 type signatures. Replaces the Dependabot bump in #64, which couldn't merge in isolation.

## What changed
- \`ZodObject\` generic collapsed from 3–5 type params to 2 in zod 4 — all 25 call sites updated to \`z.ZodObject<any, any>\`
- Added an explicit \`ReturnType<typeof createTool>\` annotation on the Mastra \`CommercetoolsTool\` to prevent TS2742 errors from dual-zod type resolution (TS would otherwise reach into Mastra's transitively-pinned zod 3)
- Updated 2 customer-group tests to use \`ZodError.issues\` (zod 4) instead of the removed \`.errors\` / \`.formErrors\` accessors
- Dropped the unused \`zod-to-json-schema\` dependency (no source imports; \`z.toJSONSchema()\` is built into zod 4 for future use)

## Test plan
- [x] \`pnpm --filter @commercetools/agent-essentials run validate\` — 1651 tests pass
- [x] \`pnpm --filter @commercetools/mcp-essentials run validate\` — 93 tests pass
- [x] \`pnpm --filter @commercetools/agent-essentials run build\` — DTS + ESM + CJS all green

## Notes
- \`@langchain/core@0.3.x\` peer-pins \`zod ^3.25.32\`; installing this release will surface a peer warning for consumers of the langchain adapter, but no functional break (langchain's runtime code doesn't call zod-v4-only APIs). The warning resolves once the langchain example migrates to v1.x (tracked in #67).
- Breaking change for SDK consumers that define their own zod schemas — changeset entry marks this as a \`major\` bump for both packages.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)